### PR TITLE
After hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "qwikql",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qwikql",
-      "version": "0.0.1",
+      "version": "0.0.2",
+      "license": "MIT",
       "devDependencies": {
-        "@builder.io/qwik": "0.9.0",
+        "@builder.io/qwik": "0.14.0",
         "@types/eslint": "8.4.6",
         "@types/node": "latest",
         "@typescript-eslint/eslint-plugin": "5.37.0",
@@ -28,7 +29,7 @@
         "node": ">=15.0.0"
       },
       "peerDependencies": {
-        "@builder.io/qwik": "0.9.0",
+        "@builder.io/qwik": "^0.14.0",
         "graphql": "^16.6.0",
         "graphql-request": "^5.0.0"
       }
@@ -140,15 +141,15 @@
       }
     },
     "node_modules/@builder.io/qwik": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.9.0.tgz",
-      "integrity": "sha512-xAyQNABvPe/V0xGKuAaUJcP9r+qNegWegkstRQza/CgJ3vgR20yyaYzkcAD+G9wvPeG1mRSiUZAYDgevV2BLaQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.14.0.tgz",
+      "integrity": "sha512-l5FCgtkqaHJkBZQujsTAtp5NDqG4bGIblxYq5d7Bsk16XFFS8zOkHxy9UcfYiKYeIQ0irFMX3RE9zByDog/tkA==",
       "dev": true,
       "bin": {
         "qwik": "qwik.cjs"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -6597,9 +6598,9 @@
       }
     },
     "@builder.io/qwik": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.9.0.tgz",
-      "integrity": "sha512-xAyQNABvPe/V0xGKuAaUJcP9r+qNegWegkstRQza/CgJ3vgR20yyaYzkcAD+G9wvPeG1mRSiUZAYDgevV2BLaQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.14.0.tgz",
+      "integrity": "sha512-l5FCgtkqaHJkBZQujsTAtp5NDqG4bGIblxYq5d7Bsk16XFFS8zOkHxy9UcfYiKYeIQ0irFMX3RE9zByDog/tkA==",
       "dev": true
     },
     "@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "qwik": "qwik"
   },
   "peerDependencies": {
-    "@builder.io/qwik": "0.9.0",
+    "@builder.io/qwik": "^0.9.0",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "graphql-request": "^5.0.0"
   },
   "devDependencies": {
-    "@builder.io/qwik": "0.9.0",
+    "@builder.io/qwik": "0.14.0",
     "@types/eslint": "8.4.6",
     "@types/node": "latest",
     "@typescript-eslint/eslint-plugin": "5.37.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "qwik": "qwik"
   },
   "peerDependencies": {
-    "@builder.io/qwik": "^0.9.0",
+    "@builder.io/qwik": "^0.14.0",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0"
   },

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,6 +1,6 @@
 import { createContext, QRL } from '@builder.io/qwik'
 
-export const QwikqlURLContext = createContext<{ url: string, after?: (args: any) => Promise<void> }>('qwikql.url')
+export const QwikqlURLContext = createContext<{ url: string, after$?: QRL<(args: any) => void> }>('qwikql.url')
 export const QwikqlRequestContextContext = createContext<{
   headers: Record<string, string>
 }>('qwikql.requestContext')

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,6 +1,7 @@
 import { createContext, QRL } from '@builder.io/qwik'
+import { Response } from './types';
 
-export const QwikqlURLContext = createContext<{ url: string, after$?: QRL<(args: any) => void> }>('qwikql.url')
+export const QwikqlURLContext = createContext<{ url: string, after$: QRL<(resp: Response) => void> }>('qwikql.url')
 export const QwikqlRequestContextContext = createContext<{
   headers: Record<string, string>
 }>('qwikql.requestContext')

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,6 +1,6 @@
 import { createContext, QRL } from '@builder.io/qwik'
 
-export const QwikqlURLContext = createContext<{ url: string }>('qwikql.url')
+export const QwikqlURLContext = createContext<{ url: string, after?: (args: any) => Promise<void> }>('qwikql.url')
 export const QwikqlRequestContextContext = createContext<{
   headers: Record<string, string>
 }>('qwikql.requestContext')

--- a/src/qwikql-component.tsx
+++ b/src/qwikql-component.tsx
@@ -11,6 +11,7 @@ import {
   QwikqlSetHeadersContext,
   QwikqlURLContext
 } from './contexts'
+import { Response } from './types';
 
 interface QwikQLProps {
   url: string

--- a/src/qwikql-component.tsx
+++ b/src/qwikql-component.tsx
@@ -1,6 +1,7 @@
 import {
   $,
   component$,
+  QRL,
   Slot,
   useContextProvider,
   useStore
@@ -14,7 +15,10 @@ import {
 interface QwikQLProps {
   url: string
   headers?: Record<string, string>
+  after$?: QRL<((resp: Response) => {})>
 }
+
+export const defaultAfter = $(() => {});
 
 export const QwikQL = component$((props: QwikQLProps) => {
   if (!props.url) {
@@ -23,7 +27,7 @@ export const QwikQL = component$((props: QwikQLProps) => {
 
   const context = useStore({ headers: props.headers || {} })
 
-  useContextProvider(QwikqlURLContext, { url: props.url })
+  useContextProvider(QwikqlURLContext, { url: props.url, after$: props.after$ || defaultAfter })
   useContextProvider(QwikqlRequestContextContext, context)
   useContextProvider(
     QwikqlSetHeadersContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+import { rawRequest } from "graphql-request"
+
 export interface QwikqlError {
   message: string
 }
+
+export type Response = Awaited<ReturnType<typeof rawRequest>>;

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -7,11 +7,9 @@ interface QueryConfig {
   variables?: Record<string, any>
 }
 
-export const defaultAfter$ = $(() => {});
-
 export const useQuery = (query: RequestDocument) => {
   const queryAsString = query.toString()
-  const { url, after$ = defaultAfter$ } = useContext(QwikqlURLContext)
+  const { url, after$ } = useContext(QwikqlURLContext)
   const requestContext = useContext(QwikqlRequestContextContext)
 
   const executeQuery$ = $(async (queryConfig: Partial<QueryConfig> = {}) => {

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -7,14 +7,12 @@ interface QueryConfig {
   variables?: Record<string, any>
 }
 
-export const defaultAfter = () => {};
+export const defaultAfter$ = $(() => {});
 
 export const useQuery = (query: RequestDocument) => {
   const queryAsString = query.toString()
-  const { url, after } = useContext(QwikqlURLContext)
+  const { url, after$ = defaultAfter$ } = useContext(QwikqlURLContext)
   const requestContext = useContext(QwikqlRequestContextContext)
-
-  const qwikAfter$ = $(after || defaultAfter)
 
   const executeQuery$ = $(async (queryConfig: Partial<QueryConfig> = {}) => {
     try {
@@ -25,7 +23,7 @@ export const useQuery = (query: RequestDocument) => {
         requestContext.headers
       );
 
-      qwikAfter$(response);
+      after$(response);
 
       return response.data;
     } catch (error) {


### PR DESCRIPTION
I have a use case where I need to save some info from response headers after a successful GraphQL request. Specifically, this is needed in order to correctly [authenticate with Vendure](https://www.vendure.io/docs/storefront/managing-sessions/).

With this PR I propose a way to do this by passing in a QRL called `after$` to the `QwikQL` component. Example usage:

```ts
    <QwikQL url={`${import.meta.env.VITE_VENDURE_URL}/shop-api`} after$={$((resp: Response) => {
      store.token = resp.headers.get('vendure-auth-token');
    })}>
```

We would obviously need to modify `useMutation` in the same way that `useQuery` is modified here, but I figured I'd stop here to get feedback on the proposal before going further.

Also worth mentioning is the peer dependency change. Qwik is moving, ahem, quickly! And the peer deps as they're currently set up don't allow for anything after `0.9.0`. I tried fixing that with a `^` but it wasn't working out, so we can discuss how that should be approached as well.